### PR TITLE
Add LongTracer — open-source RAG hallucination detection SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ This framework consists of three components: Self-Evaluation, Internal Consisten
 - [Vectara LLM Hallucination Leaderboard](https://github.com/vectara/hallucination-leaderboard)
 - [TofuEval: Evaluating Hallucinations of LLMs on Topic-Focused Dialogue Summarization](https://arxiv.org/abs/2402.13249)
 - [UQLM: Uncertainty Quantification for Language Models](https://github.com/cvs-health/uqlm)
+- [LongTracer](https://github.com/ENDEVSOLS/LongTracer) - Open-source RAG hallucination detection SDK. Verifies LLM claims against source documents using hybrid STS + NLI, with pluggable backends and LangChain/LlamaIndex/Haystack adapters.
 
 
 ## Open Source Models for Measuring Hallucinations


### PR DESCRIPTION
LongTracer is an open-source Python SDK for detecting hallucinations in RAG pipelines.

- Verifies LLM claims against source documents using hybrid STS + NLI
- Works with LangChain, LlamaIndex, Haystack, LangGraph in 3 lines
- Pluggable backends: SQLite, MongoDB, Redis, PostgreSQL
- MIT licensed, published on PyPI: pip install longtracer
- GitHub: https://github.com/ENDEVSOLS/LongTracer
